### PR TITLE
Shorten session cache to six hours

### DIFF
--- a/apps-script/webappAuthDirectory.js
+++ b/apps-script/webappAuthDirectory.js
@@ -994,11 +994,11 @@ function createUserSession(email) {
     created: new Date().getTime()
   };
   
-  // Store in cache with 24-hour expiration
+  // Store in cache with 6-hour expiration
   CacheService.getScriptCache().put(
-    'session:' + sessionId, 
-    JSON.stringify(userData), 
-    24 * 60 * 60 // 24 hours
+    'session:' + sessionId,
+    JSON.stringify(userData),
+    6 * 60 * 60 // 6 hours
   );
   
   return sessionId;


### PR DESCRIPTION
## Summary
- lower session CacheService expiration from 24h to 6h

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b74fab92d08321afdaff136a996535