### PR TITLE
Allow embedding of director and lead dashboards

### DIFF
--- a/apps-script/webappAuthDirectory.js
+++ b/apps-script/webappAuthDirectory.js
@@ -347,7 +347,10 @@ function renderDirectorDashboard(user) {
       </script>
     </body>
     </html>
-  `).setTitle('CLEAR — Director Dashboard');
+  `)
+    .setTitle('CLEAR — Director Dashboard')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
+    .setSandboxMode(HtmlService.SandboxMode.IFRAME);
 }
 
 // For directors
@@ -465,7 +468,10 @@ function renderLeadDashboard(user) {
       </script>
     </body>
     </html>
-  `).setTitle('CLEAR — Lead Dashboard');
+  `)
+    .setTitle('CLEAR — Lead Dashboard')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL)
+    .setSandboxMode(HtmlService.SandboxMode.IFRAME);
 }
 
 function renderEmployeeDashboard(user) {


### PR DESCRIPTION
## Summary
- Allow Director dashboard to be embedded by explicitly permitting iframes.
- Allow Lead dashboard to be embedded with matching X-Frame and sandbox settings.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b74faabd108321beb30126c1222980