### PR TITLE
Fix login redirect to preserve base URL

### DIFF
--- a/apps-script/webappAuthDirectory.js
+++ b/apps-script/webappAuthDirectory.js
@@ -139,7 +139,8 @@ function renderLoginPage() {
           if (result.ok) {
             showMsg('Login successful! Redirecting...', 'success');
             // Simple redirect that should work
-            window.location.href = '?session=' + result.sessionId;
+            const base = window.location.href.split('?')[0];
+            window.location.href = base + '?session=' + result.sessionId;
           } else {
             showMsg(result.error || 'Login failed', 'error');
             btn.disabled = false;


### PR DESCRIPTION
## Summary
- Ensure login redirect retains base URL before adding session query

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b74fa2c7ac832182f97e5f92ee6128