### PR TITLE
Ensure session redirect waits for backend

### DIFF
--- a/apps-script/webappAuthDirectory.js
+++ b/apps-script/webappAuthDirectory.js
@@ -138,9 +138,13 @@ function renderLoginPage() {
         .withSuccessHandler(function(result) {
           if (result.ok) {
             showMsg('Login successful! Redirecting...', 'success');
-            // Simple redirect that should work
             const base = window.location.href.split('?')[0];
-            window.location.href = base + '?session=' + result.sessionId;
+            google.script.run
+              .withSuccessHandler(() => {
+                google.script.host.close();
+                window.open(base + '?session=' + result.sessionId, '_top');
+              })
+              .closeAndReopenWithSession(result.sessionId);
           } else {
             showMsg(result.error || 'Login failed', 'error');
             btn.disabled = false;


### PR DESCRIPTION
## Summary
- Ensure login success waits for backend close before redirecting

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b020a9ac8321b954a946a92faaa8