### PR TITLE
Close iframe on login to reload web app with session

### DIFF
--- a/apps-script/webappAuthDirectory.js
+++ b/apps-script/webappAuthDirectory.js
@@ -138,9 +138,10 @@ function renderLoginPage() {
         .withSuccessHandler(function(result) {
           if (result.ok) {
             showMsg('Login successful! Redirecting...', 'success');
-            // Simple redirect that should work
+            // Close the iframe and reload the web app with the session ID
             const base = window.location.href.split('?')[0];
-            window.location.href = base + '?session=' + result.sessionId;
+            google.script.host.close();
+            window.open(base + '?session=' + result.sessionId, '_top');
           } else {
             showMsg(result.error || 'Login failed', 'error');
             btn.disabled = false;


### PR DESCRIPTION
## Summary
- close login iframe and reload the entire web app with session ID

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b8afd533e083218d855e5adea6eb2b