### PR TITLE
fix: clean login success redirect in auth directory

### DIFF
--- a/apps-script/webappAuthDirectory.js
+++ b/apps-script/webappAuthDirectory.js
@@ -145,7 +145,6 @@ function renderLoginPage() {
                 window.open(base + '?session=' + result.sessionId, '_top');
               })
               .closeAndReopenWithSession(result.sessionId);
-       main
           } else {
             showMsg(result.error || 'Login failed', 'error');
             btn.disabled = false;


### PR DESCRIPTION
## Summary
- remove stray merge line from webappAuthDirectory login redirect block
- ensure google.script.run closes and reopens with session before redirect

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build` *(fails: Missing script: "build")*

------
https://chatgpt.com/codex/tasks/task_e_68b8b7d8be8483219d47218f44ea787b